### PR TITLE
ci: 忽略小米推送 SDK 的测试覆盖率

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "home/push/mipush"


### PR DESCRIPTION
小米推送SDK的测试覆盖率没有意义。

<https://docs.codecov.io/docs/ignoring-paths>