### PR TITLE
fix(push): 修复推送时，只有一个设备接收到的问题

### DIFF
--- a/home/push/tasks.py
+++ b/home/push/tasks.py
@@ -67,4 +67,4 @@ def push_to_users(reg_ids: List[str],
     <https://dev.mi.com/console/doc/detail?pId=1278#_2_1>
     """
     message = build_message(title, description, payload, channel)
-    return sender.send(message.message_dict(), reg_ids)
+    return sender.send(message.message_dict(), ','.join(reg_ids))


### PR DESCRIPTION
原来推送的格式不对

[文档](https://dev.mi.com/console/doc/detail?pId=1163)：可以提供多个registration_id，发送给一组设备，不同的registration_id之间用“,”分割。