### PR TITLE
ci: 使用新版设置输出的格式

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,11 +47,11 @@ jobs:
           VERSION=$(poetry version -s)
           COMMIT_ID=$(git rev-parse --short HEAD)
           if [[ "${{github.event_name}}" == "release" && "${{github.event.action}}" == "published" ]]; then
-            echo "::set-output name=environment::prod"
-            echo "::set-output name=version::$VERSION"
+            echo "environment=prod" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=environment::dev"
-            echo "::set-output name=version::$VERSION-git.$COMMIT_ID"
+            echo "environment=dev" >> $GITHUB_OUTPUT
+            echo "version=$VERSION-git.$COMMIT_ID" >> $GITHUB_OUTPUT
           fi
       - name: Install prerequisites
         run: poetry install


### PR DESCRIPTION
旧版将会在明年停止使用。

<https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/>