### PR TITLE
fix: 修复设备状态不正确的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Fixed
 
 - 修复小米推送无法使用的问题
+- 修复设备状态不正确的问题
 
 ## [0.9.2] - 2022-10-19
 


### PR DESCRIPTION
当在线时间与离线时间的差值小于 20 秒（当前 WebSocket 的超时时间）时，则不修改状态。