### PR TITLE
chore(deps): 升级 Django 至 6.0

### DIFF
--- a/home/board/admin.py
+++ b/home/board/admin.py
@@ -3,16 +3,14 @@ from django.contrib import admin
 from .models import Comment, Topic
 
 
+@admin.register(Topic)
 class TopicAdmin(admin.ModelAdmin):
     list_display = ("title", "description", "user", "created_at")
     search_fields = ["title", "description"]
 
 
+@admin.register(Comment)
 class CommentAdmin(admin.ModelAdmin):
     list_filter = ("topic",)
     list_display = ("topic", "user", "body", "reply_to", "created_at")
     search_fields = ["body"]
-
-
-admin.site.register(Topic, TopicAdmin)
-admin.site.register(Comment, CommentAdmin)

--- a/home/push/admin.py
+++ b/home/push/admin.py
@@ -3,9 +3,7 @@ from django.contrib import admin
 from .models import MiPush
 
 
+@admin.register(MiPush)
 class MiPushAdmin(admin.ModelAdmin):
     list_filter = ("user",)
     list_display = ("user", "enable", "reg_id", "device_id", "model")
-
-
-admin.site.register(MiPush, MiPushAdmin)

--- a/home/settings/settings.py
+++ b/home/settings/settings.py
@@ -189,7 +189,6 @@ TIME_ZONE = "Asia/Shanghai"
 
 USE_I18N = True
 
-USE_L10N = True
 
 USE_TZ = True
 

--- a/home/storage/admin.py
+++ b/home/storage/admin.py
@@ -3,11 +3,13 @@ from django.contrib import admin
 from .models import Item, Picture, Storage
 
 
+@admin.register(Storage)
 class StorageAdmin(admin.ModelAdmin):
     list_display = ("name", "parent", "description")
     search_fields = ["name", "description"]
 
 
+@admin.register(Picture)
 class PictureAdmin(admin.ModelAdmin):
     list_filter = ("item",)
     list_display = ("item", "picture", "description", "created_at", "created_by")
@@ -18,6 +20,7 @@ class PictureInline(admin.TabularInline):
     extra = 1
 
 
+@admin.register(Item)
 class ItemAdmin(admin.ModelAdmin):
     inlines = [PictureInline]
     list_display = (
@@ -38,8 +41,3 @@ class ItemAdmin(admin.ModelAdmin):
     @admin.display(description="耗材")
     def get_consumables(self, obj):
         return "\n".join([p.name for p in obj.consumables.all()])
-
-
-admin.site.register(Storage, StorageAdmin)
-admin.site.register(Item, ItemAdmin)
-admin.site.register(Picture, PictureAdmin)

--- a/home/urls.py
+++ b/home/urls.py
@@ -34,7 +34,7 @@ urlpatterns = [
     *static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT),
 ]
 
-if settings.DEBUG:  # pragma: no cover
+if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:  # pragma: no cover
     urlpatterns = [
         path("__debug__/", include("debug_toolbar.urls")),
         *urlpatterns,

--- a/home/users/admin.py
+++ b/home/users/admin.py
@@ -143,6 +143,7 @@ class OwnerFilter(admin.SimpleListFilter):
             return queryset.filter(user=request.user)
 
 
+@admin.register(Session)
 class SessionAdmin(admin.ModelAdmin):
     list_display = ("ip", "user", "is_valid", "last_activity", "location", "device")
     exclude = ("session_key",)
@@ -161,14 +162,11 @@ class SessionAdmin(admin.ModelAdmin):
         return parse_device(obj.user_agent) if obj.user_agent else ""
 
 
+@admin.register(Avatar)
 class AvatarAdmin(admin.ModelAdmin):
     list_display = ("user", "avatar")
 
 
+@admin.register(Config)
 class ConfigAdmin(admin.ModelAdmin):
     list_display = ("user", "key", "value")
-
-
-admin.site.register(Session, SessionAdmin)
-admin.site.register(Avatar, AvatarAdmin)
-admin.site.register(Config, ConfigAdmin)

--- a/home/users/middleware.py
+++ b/home/users/middleware.py
@@ -21,10 +21,10 @@ class SessionMiddleware(BaseSessionMiddleware):
         session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME)
         # 获取代理下的客户端 IP 地址
         # https://django-user-sessions.readthedocs.io/en/stable/installation.html#ip-when-behind-a-proxy
-        if "HTTP_X_FORWARDED_FOR" in request.META:
-            request.META["REMOTE_ADDR"] = request.META["HTTP_X_FORWARDED_FOR"].split(",")[0].strip()
+        if "x-forwarded-for" in request.headers:
+            request.META["REMOTE_ADDR"] = request.headers["x-forwarded-for"].split(",")[0].strip()
         request.session = self.SessionStore(
             ip=request.META.get("REMOTE_ADDR", ""),
-            user_agent=request.META.get("HTTP_USER_AGENT", ""),
+            user_agent=request.headers.get("user-agent", ""),
             session_key=session_key,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.14.4"
 dependencies = [
-  "django>=5.2.16,<6.0",
+  "django>=6.0.7,<6.1",
   "strawberry-graphql-django>=0.86.5",
   "channels>=4.3.2",
   "channels-redis[cryptography]>=4.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -600,16 +600,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.16"
+version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/55/664f24ff81c9ea19cb7dfc851afeae1f3c2390c7aee01d4ded68b5c1580d/django-6.0.7.tar.gz", hash = "sha256:2998503fc083124fb58037084bfa00de323c7c743f05f1b4284e77bff0ab8890", size = 10921299, upload-time = "2026-07-07T13:51:26.485Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/13/1e5e3e4c15dcecb04281b3cb2a46a4670e1cef131068e202f6040df19224/django-5.2.16-py3-none-any.whl", hash = "sha256:04f354bf9d807a86ad1a8392fe3808d362358a8eafc322848e0e43e59b24371d", size = 8311943, upload-time = "2026-07-07T13:52:11.223Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ec/1ce5334b6a2c52ce619c23a0be8d366a57a0e080ebb2d88266e5c849157c/django-6.0.7-py3-none-any.whl", hash = "sha256:a037427c2288443a8c02a1b02295a31c239663aa682bc50b1976afb7cf6a769e", size = 8373344, upload-time = "2026-07-07T13:51:20.007Z" },
 ]
 
 [[package]]
@@ -1624,7 +1624,7 @@ requires-dist = [
     { name = "celery", specifier = ">=5.6.3" },
     { name = "channels", specifier = ">=4.3.2" },
     { name = "channels-redis", extras = ["cryptography"], specifier = ">=4.3.0" },
-    { name = "django", specifier = ">=5.2.16,<6.0" },
+    { name = "django", specifier = ">=6.0.7,<6.1" },
     { name = "django-celery-beat", specifier = ">=2.9.0" },
     { name = "django-cleanup", specifier = ">=9.0.0" },
     { name = "django-mptt", specifier = ">=0.18.0" },


### PR DESCRIPTION
## 变更内容

- 将 Django 从 5.2.16 升级至 6.0.7，并约束在 `<6.1`
- 重新生成 `uv.lock`
- 使用 `django-upgrade --target-version 6.0` 更新 Admin 注册和请求头访问方式
- 删除已失效的 `USE_L10N` 设置
- 仅在 `debug_toolbar` 已注册时加载其 URL，兼容 Django 6 更严格的模型归属检查

## 升级影响

- Django 6 要求 Python 3.12 及以上，项目当前使用 Python 3.14.4，满足要求
- 不涉及数据库模型变化，无需新增 migration
- 不改变对外 API 或用户配置
- Eventlet 的上游弃用警告仍然存在，本次不调整现有 worker 方案

## 本地验证

- 基础、开发、生产配置 `manage.py check` 均通过
- `manage.py makemigrations --check --dry-run`：无变更
- `uv run poe test`：160 项测试全部通过
- `django-upgrade --target-version 6.0 --check`：通过
- Ruff、格式和 pre-commit 检查通过
- `pip-audit`：未发现已知漏洞

## Actions 验证

本地 `wslc build` 在拉取 Docker Hub 匿名令牌时连续网络超时，失败发生在读取 Dockerfile 基础镜像阶段，尚未进入项目构建步骤。请由 GitHub Actions 继续验证 Linux 环境测试和生产 Docker 镜像构建。
